### PR TITLE
Fix UnicodeEncodeError when exporting playlists with special characters

### DIFF
--- a/src/yt_playlist_export/yt_playlist_export.py
+++ b/src/yt_playlist_export/yt_playlist_export.py
@@ -75,7 +75,7 @@ def print_csv(info: any):
     if output is None:
         csv_file = sys.stdout
     else:
-        csv_file = open(output, mode='w', newline='')
+        csv_file = open(output, mode='w', newline='', encoding='utf-8')
     writer = csv.DictWriter(csv_file, fieldnames=header)
     writer.writeheader()
     for row in convert_to_csv(info):


### PR DESCRIPTION
I encountered an issue when exporting playlists that contain special characters or emojis in the video title. The script throws the following error:

`UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f165' in position 160: character maps to <undefined>`

The issue occurs because the script does not specify the encoding when writing the CSV file. On Windows, the default encoding does not support certain characters (cp1252)

To fix this issue, I added encoding="utf-8" when opening the file in print_csv. Here's the updated code:

```python
def print_csv(info: any):
    global output
    if output is None:
        csv_file = sys.stdout
    else:
        csv_file = open(output, mode='w', newline='', encoding='utf-8')
    writer = csv.DictWriter(csv_file, fieldnames=header)
    writer.writeheader()
    for row in convert_to_csv(info):
        writer.writerow(row)
```