### PR TITLE
Support ytdlp cookie syntax

### DIFF
--- a/src/yt_playlist_export/yt_playlist_export.py
+++ b/src/yt_playlist_export/yt_playlist_export.py
@@ -111,7 +111,7 @@ def parse_browser_string(browserCookieString):
     container = None if container_pos < 0 else browserCookieString[container_pos+2:]
 
     # the order is swapped for the Python ytdlp api
-    return (browser, profile, keyring, container)
+    return (browser, None if profile == "" else profile, None if keyring == "" else keyring, None if container == "" else container)
 
 # See help(yt_dlp.YoutubeDL) for a list of available options and public functions
 ydl_opts = {


### PR DESCRIPTION
Thanks for this tool, I found it really helpful!
I use youtube in a firefox container in a non-default profile directory. This PR adds support for parsing the --browser option and allows you to specify the browser profile and/or container if not the default, same as per yt-dlp. If there is any error it should fall back to just passing the arg through unaltetred, same as before.